### PR TITLE
h-sutra: broaden HEADER_RE verb char-class to accept + / _ (audit C2)

### DIFF
--- a/marketplace/plugin/hooks/h-sutra-enforce.sh
+++ b/marketplace/plugin/hooks/h-sutra-enforce.sh
@@ -120,7 +120,7 @@ fi
 FIRST_LINE=$(printf '%s' "$FIRST_TEXT_OF_TURN" | head -1)
 FIRST200=$(printf '%s' "$FIRST_TEXT_OF_TURN" | head -c 200)
 
-HEADER_RE='^\[(D[0-9]+|[A-Z0-9-]+)·([A-Z0-9-]+)( · (TIMING|TENSE|CHANNEL|REV|RISK|attempt):[^]·]+)*\]|^\[STAGE-1-FAIL · CLARIFY( · attempt:[0-9]+/[0-9]+)?\]'
+HEADER_RE='^\[(D[0-9]+|[A-Z0-9-]+)·([A-Z0-9+/_-]+)( · (TIMING|TENSE|CHANNEL|REV|RISK|attempt):[^]·]+)*\]|^\[STAGE-1-FAIL · CLARIFY( · attempt:[0-9]+/[0-9]+)?\]'
 
 if printf '%s' "$FIRST_LINE" | grep -qE "$HEADER_RE"; then
   audit_log "pass" "$FIRST200" "header_matched"

--- a/marketplace/plugin/tests/unit/test-h-sutra-header-regex.sh
+++ b/marketplace/plugin/tests/unit/test-h-sutra-header-regex.sh
@@ -1,0 +1,72 @@
+#!/bin/bash
+# Test: h-sutra-enforce.sh HEADER_RE accepts compound verb chars (+, /, _).
+# Fix for vinit-audit-2026-05-20 C2 — verb char-class was [A-Z0-9-]; rejected
+# valid headers like [INPUT·FETCH+BUILD · ...] forcing 4x re-emit token cost.
+# Broadened to [A-Z0-9+/_-]. Hyphen kept at end of class for literal interpretation.
+
+set -u
+
+PLUGIN_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+HOOK="$PLUGIN_ROOT/hooks/h-sutra-enforce.sh"
+
+PASS=0
+FAIL=0
+FAILURES=()
+
+# Extract HEADER_RE directly from the hook (avoids drift between test and source).
+HEADER_RE=$(awk '/^HEADER_RE=/ { sub(/^HEADER_RE=./,""); sub(/.$/,""); print; exit }' "$HOOK")
+
+if [ -z "$HEADER_RE" ]; then
+  echo "FATAL: could not extract HEADER_RE from $HOOK"
+  exit 2
+fi
+
+_assert() {
+  local name="$1" expected="$2" header="$3"
+  local actual
+  if printf '%s' "$header" | grep -qE "$HEADER_RE"; then
+    actual="match"
+  else
+    actual="no-match"
+  fi
+  if [ "$expected" = "$actual" ]; then
+    PASS=$((PASS+1))
+    echo "  PASS: $name"
+  else
+    FAIL=$((FAIL+1))
+    FAILURES+=("$name :: expected=$expected actual=$actual header='$header'")
+    echo "  FAIL: $name (expected=$expected actual=$actual)"
+  fi
+}
+
+echo "== HEADER_RE acceptance — compound verbs (C2 fix) =="
+_assert "compound + verb"        "match" '[INPUT·FETCH+BUILD · TIMING:NOW · CHANNEL:CLI · REV:LOW · RISK:LOW]'
+_assert "compound + verb alt"    "match" '[INPUT·PUSH+FILE · TIMING:NOW · CHANNEL:CLI · REV:LOW · RISK:LOW]'
+_assert "slash verb"             "match" '[REVIEW·PUSH/FILE · TIMING:NOW · CHANNEL:CLI · REV:LOW · RISK:LOW]'
+_assert "underscore verb"        "match" '[ASAWA·FOO_BAR · TIMING:NOW · CHANNEL:CLI · REV:LOW · RISK:LOW]'
+
+echo "== HEADER_RE acceptance — legacy shapes (regression) =="
+_assert "simple verb"            "match" '[INPUT·BUILD · TIMING:NOW · CHANNEL:CLI · REV:LOW · RISK:LOW]'
+_assert "review gate"            "match" '[REVIEW·GATE · TIMING:NOW · CHANNEL:CLI · REV:LOW · RISK:LOW]'
+_assert "stage-1-fail"           "match" '[STAGE-1-FAIL · CLARIFY · attempt:1/1]'
+_assert "D-prefix direction"     "match" '[D38·VERIFY · TIMING:NOW · CHANNEL:CLI · REV:LOW · RISK:LOW]'
+
+echo "== HEADER_RE rejection — malformed (negative) =="
+_assert "no middot"              "no-match" '[INPUT BUILD]'
+_assert "no bracket"             "no-match" 'No bracket at all'
+_assert "lowercase verb"         "no-match" '[INPUT·build · TIMING:NOW]'
+_assert "lowercase direction"    "no-match" '[lowercase·BUILD]'
+
+echo ""
+echo "== Summary =="
+echo "PASS: $PASS"
+echo "FAIL: $FAIL"
+if [ "$FAIL" -gt 0 ]; then
+  echo ""
+  echo "Failures:"
+  for f in "${FAILURES[@]}"; do
+    echo "  - $f"
+  done
+  exit 1
+fi
+exit 0


### PR DESCRIPTION
## Summary

One-char regex broadening + first regex unit test for `hooks/h-sutra-enforce.sh`.

Audit finding C2 from `/Users/vinit/sutra-findings-2026-05-20.md` (T4 fleet review by Vinit Harmalkar).

## Problem

`HEADER_RE` verb char-class was `[A-Z0-9-]` — rejected valid compound verbs like:

- `[INPUT·FETCH+BUILD · ...]`
- `[INPUT·PUSH+FILE · ...]`
- `[REVIEW·PUSH/FILE · ...]`
- `[ASAWA·FOO_BAR · ...]`

Each rejection forced a complete response re-emit (~4× token cost). The audit session itself paid ~3k tokens to one such rejection.

Misleading error: hook said *"did not start with H-Sutra header"* — the header DID start with bracket-direction-verb. The verb just contained `+`.

## Fix

One-character broadening: verb capture group now accepts `+`, `/`, `_`.
Hyphen kept at end of POSIX bracket for literal interpretation.

Direction class (first capture group) NOT touched — directions stay strict `[A-Z0-9-]`.

## Tests

New file: `marketplace/plugin/tests/unit/test-h-sutra-header-regex.sh` — first regex unit test for this hook.

12 cases:
- 4 compound-verb acceptance (the fix)
- 4 legacy regression (`[INPUT·BUILD]`, `[REVIEW·GATE]`, `[STAGE-1-FAIL·CLARIFY]`, `[D38·VERIFY]`)
- 4 malformed negative (no middot, no bracket, lowercase verb, lowercase direction)

Result: PASS 12 / FAIL 0. Verified on BSD grep (macOS Darwin).

## Test plan
- [x] `bash marketplace/plugin/tests/unit/test-h-sutra-header-regex.sh` exits 0
- [x] 12/12 cases PASS on BSD grep Darwin
- [x] Negative cases still rejected (regression-proof)
- [ ] Maintainer: confirm on GNU grep Linux (likely identical, but worth a CI run)

## Audit context

See `/Users/vinit/sutra-findings-2026-05-20.md` for full audit. C2 is one of 3 CRITICAL findings. Wave 1A also flagged H4 (task-reminder false positive) — turns out to be Claude Code harness-side, not plugin-fixable; will be filed with Anthropic separately.

Audit fix.