### PR TITLE
fix(security): A10 — wire outbound egress scrubber into codex/deepseek lanes

### DIFF
--- a/marketplace/plugin/bin/peer-review-payload-scrub.sh
+++ b/marketplace/plugin/bin/peer-review-payload-scrub.sh
@@ -1,0 +1,82 @@
+#!/bin/bash
+# sutra/marketplace/plugin/bin/peer-review-payload-scrub.sh
+# A10 — outbound egress scrubber for the peer-review lanes (codex-sutra, deepseek).
+#
+# WHY: both lanes send diffs / file contents to a third-party AI API. Secrets or
+# PII in that payload would leak. This wraps lib/privacy-sanitize.sh scrub_text()
+# and is called by each skill BEFORE the payload is sent.
+#
+# Contract:
+#   peer-review-payload-scrub.sh <file>
+#     stdout : scrubbed payload (safe to egress)
+#     stderr : "SCRUB redacted=<N> bytes=<B>"  (N = redaction tokens introduced)
+#     exit 0 : ok (N >= 0)   — never blocks; auto-redacts + reports
+#     exit 2 : usage error (missing arg / unreadable file) — caller must abort
+#     exit 3 : oversize (> MAX_BYTES) — caller runs AskUserQuestion (truncate vs abort)
+#     exit 4 : binary input (non-text) — refuse; never egress binary
+#
+# Fail-closed: on any internal error the script exits non-zero rather than
+# emitting an unscrubbed payload.
+set -uo pipefail
+
+MAX_BYTES="${PEER_REVIEW_SCRUB_MAX_BYTES:-512000}"   # 500 KB
+
+# Locate lib relative to this script (bin/ and lib/ are siblings under plugin/)
+SELF_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+LIB="$SELF_DIR/../lib/privacy-sanitize.sh"
+
+FILE="${1:-}"
+
+# --- usage / readability guards (exit 2) ---
+if [ -z "$FILE" ]; then
+  echo "SCRUB error=usage reason=missing_file_arg" >&2
+  exit 2
+fi
+if [ ! -f "$FILE" ] || [ ! -r "$FILE" ]; then
+  echo "SCRUB error=usage reason=unreadable_file file=$FILE" >&2
+  exit 2
+fi
+if [ ! -f "$LIB" ] || [ ! -r "$LIB" ]; then
+  echo "SCRUB error=internal reason=privacy_lib_missing lib=$LIB" >&2
+  exit 2
+fi
+
+# --- size cap (exit 3) ---
+BYTES=$(wc -c < "$FILE" | tr -d '[:space:]')
+if [ "${BYTES:-0}" -gt "$MAX_BYTES" ]; then
+  echo "SCRUB error=oversize bytes=$BYTES max=$MAX_BYTES" >&2
+  exit 3
+fi
+
+# --- binary guard (exit 4) ---
+# A text payload is what a code reviewer expects. Refuse anything the OS classifies
+# as non-text, and as a fallback refuse any file containing a NUL byte.
+MIME=$(file -b --mime-type "$FILE" 2>/dev/null || echo "unknown")
+case "$MIME" in
+  text/*|application/json|application/xml|application/javascript|inode/x-empty|unknown) ;;
+  *) echo "SCRUB error=binary mime=$MIME file=$FILE" >&2; exit 4 ;;
+esac
+# NOTE: `grep -qU $'\x00'` does NOT work — bash cannot hold a NUL in a string,
+# so $'\x00' degrades to an empty pattern that matches EVERY file (flagging all
+# text as binary). Use tr+cmp instead: strip NULs and compare to the original;
+# if they differ, the file contained a NUL byte. Portable across BSD + GNU.
+if ! LC_ALL=C tr -d '\000' < "$FILE" | cmp -s - "$FILE"; then
+  echo "SCRUB error=binary reason=nul_byte file=$FILE" >&2
+  exit 4
+fi
+
+# --- scrub (exit 0) ---
+# shellcheck source=../lib/privacy-sanitize.sh
+. "$LIB" || { echo "SCRUB error=internal reason=lib_source_failed" >&2; exit 2; }
+
+RAW=$(cat "$FILE")
+CLEAN=$(scrub_text "$RAW")
+
+# Count redaction tokens introduced (placeholders the scrubber emits).
+# Conservative: count occurrences of each known placeholder in CLEAN.
+REDACTED=$(printf '%s' "$CLEAN" | grep -oE '<(HOME|TMP|SSH-KEY|PEM-BEGIN|PEM-END|JWT|GITHUB-TOKEN|OPENAI-KEY|AWS-KEY-ID|SLACK-TOKEN|STRIPE-KEY|SLACK-WEBHOOK|DISCORD-WEBHOOK|SIGNED-URL-PARAMS|CREDS|DB-URI|KEY=REDACTED|PHONE|EMAIL|HIGH-ENTROPY)>' 2>/dev/null | grep -c . || true)
+REDACTED="${REDACTED:-0}"
+
+printf '%s' "$CLEAN"
+echo "SCRUB redacted=$REDACTED bytes=$BYTES" >&2
+exit 0

--- a/marketplace/plugin/skills/codex-sutra/SKILL.md
+++ b/marketplace/plugin/skills/codex-sutra/SKILL.md
@@ -337,6 +337,44 @@ case.
 
 ---
 
+## Outbound scrub (mandatory, all modes — A10)
+
+Every mode (Review / Challenge / Consult / Design-review) assembles its prompt
+(boundary + persona + any embedded file/plan content) into a temp `$PROMPT_FILE`,
+then routes it through the egress scrubber BEFORE handing it to `codex exec`:
+
+```bash
+PROMPT_FILE_SCRUBBED="/tmp/codex-sutra-prompt-scrubbed.$$.$(date +%s).txt"
+SCRUB="${CLAUDE_PLUGIN_ROOT:?CLAUDE_PLUGIN_ROOT unset}/bin/peer-review-payload-scrub.sh"
+if "$SCRUB" "$PROMPT_FILE" > "$PROMPT_FILE_SCRUBBED" 2>/tmp/codex-sutra-scrub-err.$$; then
+  cat /tmp/codex-sutra-scrub-err.$$ >&2            # "SCRUB redacted=<N> bytes=<B>"
+  SCRUBBED_PROMPT=$(cat "$PROMPT_FILE_SCRUBBED")
+else
+  SCRUB_EXIT=$?
+  case "$SCRUB_EXIT" in
+    3) echo "codex-sutra: payload exceeds scrub size cap — AskUserQuestion (truncate vs abort) before egress." >&2 ;;
+    4) echo "codex-sutra: payload classified non-text/binary — refusing egress." >&2 ;;
+    *) echo "codex-sutra: scrub failed (exit $SCRUB_EXIT) — refusing egress." >&2 ;;
+  esac
+  printf '{"skill":"codex-sutra","mode":"egress","ts":"%s","verdict":"SKIPPED","reason":"scrub_exit_%s","commit":"%s"}\n' \
+    "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$SCRUB_EXIT" "$(git rev-parse --short HEAD 2>/dev/null || echo unknown)" \
+    >> .enforcement/codex-reviews/gate-log.jsonl
+  exit 0
+fi
+```
+
+All four `codex exec "<prompt>"` invocations in Steps 2A–2D pass `"$SCRUBBED_PROMPT"`
+as `<prompt>` — never the raw `$PROMPT_FILE` content.
+
+**Scope + residual exposure (honest).** This scrubs only the content Claude
+*embeds* in the prompt — design-review file contents (2D) and consult plan text
+(2C). It does NOT scrub what codex reads *itself*: `codex exec -s read-only -C
+$REPO_ROOT` is an agent that runs `git diff` and reads source files inside its
+sandbox, then sends that context to OpenAI. Prompt-scrubbing cannot intercept
+that path. Closing it requires codex-side redaction or running codex against a
+pre-scrubbed worktree — tracked as `TODO[v2-codex-sandbox-scrub]`. The deepseek
+lane has no such gap (pure API; the assembled prompt IS the entire payload).
+
 ## The launcher pattern (used by all four modes)
 
 **Single-writer rule.** The wrapper owns the final disposition. The bg

--- a/marketplace/plugin/skills/deepseek/SKILL.md
+++ b/marketplace/plugin/skills/deepseek/SKILL.md
@@ -9,9 +9,10 @@ description: |
   (single doc). Mirrors codex-sutra structurally; uses DeepSeek as the second
   AI lane for second-opinion + convergence under PROTO-019 v2 (deferred).
   v1-min ships factually correct transport + downgrade defense + auditable
-  SKIPPED logging. Governance machinery (scrubber, session-machine, preflight
-  budgeting, schema unification) is deferred to v2 with documented TODO markers
-  (see "Known v1 limitations" below).
+  SKIPPED logging + outbound egress scrubbing (A10, wired 2026-06-26).
+  Remaining governance machinery (session-machine, preflight budgeting, schema
+  unification) is deferred to v2 with documented TODO markers (see "Known v1
+  limitations" below).
 allowed-tools:
   - Bash
   - BashOutput
@@ -48,7 +49,7 @@ rounds. Final verdict ADVISORY. Trail at:
 
 | Marker | Limitation | v2 plan |
 |---|---|---|
-| TODO[v2-scrubber] | No outbound data scrubbing (binary excl / secret regex / path allowlist). v1 sends payload as-is. | Add `bin/deepseek-payload-scrub.sh` per design §B (file -b --mime-type, AWS/JWT/PEM/.env regex, ≤500 KB cap with AskUserQuestion). |
+| ~~TODO[v2-scrubber]~~ **DONE (A10)** | ~~No outbound data scrubbing~~ — payload now routed through `bin/peer-review-payload-scrub.sh` (file -b --mime-type binary excl, NUL guard, AWS/JWT/PEM/GitHub/OpenAI/Slack/Stripe/DB regex, ≤500 KB cap, fail-closed) BEFORE egress in the launcher. | Shipped. Size-cap (exit 3) AskUserQuestion + per-call redaction count surfaced on stderr. |
 | TODO[v2-session] | Consult session continuity disabled. Every `/deepseek consult` starts fresh. | Add UUID-scoped per-repo per-branch session dirs `.context/deepseek-sessions/<uuid>/`, replay redaction, --new-session flag. |
 | TODO[v2-preflight] | No pre-flight token/cost budgeting. v1 has no wall-clock cap (D2026-05-13) — relies on API-side timeouts only. | Estimate input tokens + estimated_cost preflight gate before HTTP send. |
 | TODO[v2-schema] | Separate gate-logs per skill (codex-reviews/ vs deepseek-reviews/). | Unify under canonical `sutra/os/engines/PEER-REVIEW-EVENT-SCHEMA.md`. |
@@ -214,11 +215,32 @@ TMPERR=/tmp/deepseek-err.$$.${TS}.txt
 TMPDONE=/tmp/deepseek-done.$$.${TS}        # WRAPPER WRITES ONLY
 TMPNAT=/tmp/deepseek-natural.$$.${TS}      # SUBSHELL WRITES ONLY
 
+# --- A10 outbound scrub (mandatory, fail-closed) — closes the leak that was ---
+# --- TODO[v2-scrubber]. The assembled prompt (boundary + diff + embedded files) ---
+# --- is routed through the egress scrubber BEFORE any byte leaves the machine. ---
+PROMPT_FILE_SCRUBBED="/tmp/deepseek-prompt-scrubbed.$$.${TS}.txt"
+SCRUB="${CLAUDE_PLUGIN_ROOT:?CLAUDE_PLUGIN_ROOT unset}/bin/peer-review-payload-scrub.sh"
+if "$SCRUB" "$PROMPT_FILE" > "$PROMPT_FILE_SCRUBBED" 2>/tmp/deepseek-scrub-err.$$.${TS}; then
+  cat "/tmp/deepseek-scrub-err.$$.${TS}" >&2     # surface "SCRUB redacted=<N> bytes=<B>"
+else
+  SCRUB_EXIT=$?
+  rm -f "$PROMPT_FILE_SCRUBBED"
+  case "$SCRUB_EXIT" in
+    3) echo "deepseek: payload exceeds scrub size cap — AskUserQuestion (truncate vs abort) before any egress." >&2 ;;
+    4) echo "deepseek: payload classified non-text/binary — refusing egress." >&2 ;;
+    *) echo "deepseek: scrub failed (exit $SCRUB_EXIT) — refusing egress." >&2 ;;
+  esac
+  printf '{"skill":"deepseek","mode":"egress","ts":"%s","verdict":"SKIPPED","reason":"scrub_exit_%s","commit":"%s"}\n' \
+    "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$SCRUB_EXIT" "$(git rev-parse --short HEAD 2>/dev/null || echo unknown)" \
+    >> .enforcement/deepseek-reviews/gate-log.jsonl
+  exit 0
+fi
+
 REQUEST_JSON=$(jq -nc \
   --arg model "${DEEPSEEK_MODEL:-deepseek-v4-pro}" \
   --argjson budget "${DEEPSEEK_THINKING_BUDGET:-32000}" \
   --arg effort "${DEEPSEEK_EFFORT:-high}" \
-  --rawfile prompt "$PROMPT_FILE" \
+  --rawfile prompt "$PROMPT_FILE_SCRUBBED" \
   '{
     model: $model,
     max_tokens: 8192,

--- a/marketplace/plugin/tests/integration/test-egress-scrub-wired.sh
+++ b/marketplace/plugin/tests/integration/test-egress-scrub-wired.sh
@@ -1,0 +1,114 @@
+#!/bin/bash
+# Integration test: A10 outbound egress scrubbing is WIRED into both peer-review
+# lanes (deepseek + codex-sutra), and is fail-closed.
+#
+# Two layers of assertion:
+#   (1) Static: each SKILL.md routes the prompt through peer-review-payload-scrub.sh
+#       UPSTREAM of the actual send (deepseek --rawfile / codex exec <prompt>).
+#   (2) Functional: replay the exact launcher scrub step over a payload carrying
+#       real-shaped secrets and assert (a) secrets are gone, (b) placeholders are
+#       present, (c) a binary payload is refused (exit 4 -> launcher aborts egress).
+
+set -u
+PLUGIN_ROOT="$(dirname "$(dirname "$(dirname "$(realpath "$0")")")")"
+SCRUB="$PLUGIN_ROOT/bin/peer-review-payload-scrub.sh"
+DEEPSEEK="$PLUGIN_ROOT/skills/deepseek/SKILL.md"
+CODEX="$PLUGIN_ROOT/skills/codex-sutra/SKILL.md"
+
+PASS=0; FAIL=0
+_ok() { PASS=$((PASS+1)); echo "  OK  $1"; }
+_no() { FAIL=$((FAIL+1)); echo "  X   $1"; }
+
+# ── (1) Static wiring: deepseek ──────────────────────────────────────────────
+# The scrub call must appear, and the request must read the SCRUBBED file, not raw.
+if grep -q 'peer-review-payload-scrub.sh' "$DEEPSEEK"; then
+  _ok "deepseek references the scrubber"
+else
+  _no "deepseek does NOT reference the scrubber"
+fi
+if grep -q -- '--rawfile prompt "\$PROMPT_FILE_SCRUBBED"' "$DEEPSEEK"; then
+  _ok "deepseek sends the SCRUBBED prompt file (not raw \$PROMPT_FILE)"
+else
+  _no "deepseek still sends raw \$PROMPT_FILE to the API"
+fi
+# Guard against regression: raw --rawfile of the unscrubbed file must be gone.
+if grep -q -- '--rawfile prompt "\$PROMPT_FILE"' "$DEEPSEEK"; then
+  _no "deepseek STILL has a raw --rawfile prompt \"\$PROMPT_FILE\" (leak path)"
+else
+  _ok "deepseek has no raw-payload --rawfile path"
+fi
+
+# ── (1) Static wiring: codex-sutra ───────────────────────────────────────────
+if grep -q 'peer-review-payload-scrub.sh' "$CODEX"; then
+  _ok "codex-sutra references the scrubber"
+else
+  _no "codex-sutra does NOT reference the scrubber"
+fi
+if grep -q 'SCRUBBED_PROMPT' "$CODEX"; then
+  _ok "codex-sutra defines \$SCRUBBED_PROMPT for codex exec"
+else
+  _no "codex-sutra does not define a scrubbed prompt"
+fi
+# Residual exposure must be documented honestly (not silently omitted).
+if grep -q 'TODO\[v2-codex-sandbox-scrub\]' "$CODEX"; then
+  _ok "codex-sutra documents the residual sandbox-read exposure"
+else
+  _no "codex-sutra hides the residual sandbox-read exposure"
+fi
+
+# ── (2) Functional: replay the launcher scrub step over a secret-laden payload ─
+TMP=$(mktemp -d -t egress-scrub-XXXXXX)
+PAYLOAD="$TMP/prompt.txt"
+cat > "$PAYLOAD" <<'EOF'
+Review the changes on this branch. Context:
+AWS_ACCESS_KEY_ID=AKIAIOSFODNN7EXAMPLE
+OPENAI_KEY=sk-proj-abcdef0123456789abcdef0123456789abcdef
+token=eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0.dozjgNryP4J3jVmNHl0w5N_XgL0n3I9PlFUP0THsR8U
+just a normal line of source code here
+EOF
+
+OUT="$TMP/scrubbed.txt"
+if "$SCRUB" "$PAYLOAD" > "$OUT" 2>"$TMP/err.txt"; then
+  _ok "scrubber exits 0 on a text payload (launcher would proceed)"
+else
+  _no "scrubber failed (exit $?) on a clean text payload — launcher would abort all reviews"
+fi
+
+# The raw secrets must NOT survive into the egress payload.
+if grep -q 'AKIAIOSFODNN7EXAMPLE' "$OUT"; then _no "AWS key leaked into egress payload"; else _ok "AWS key redacted"; fi
+if grep -q 'sk-proj-abcdef0123456789' "$OUT"; then _no "OpenAI key leaked into egress payload"; else _ok "OpenAI key redacted"; fi
+if grep -q 'eyJhbGciOiJIUzI1NiJ9' "$OUT"; then _no "JWT leaked into egress payload"; else _ok "JWT redacted"; fi
+# Placeholders prove redaction happened (not just deletion).
+if grep -q '<AWS-KEY-ID>\|<OPENAI-KEY>\|<JWT>\|<HIGH-ENTROPY>' "$OUT"; then
+  _ok "redaction placeholders present in egress payload"
+else
+  _no "no redaction placeholders — scrub may be a no-op"
+fi
+# Non-secret content must be preserved (scrub must not nuke the review).
+if grep -q 'normal line of source code' "$OUT"; then
+  _ok "non-secret content preserved for review"
+else
+  _no "scrub destroyed legitimate review content"
+fi
+# stderr beacon for observability.
+if grep -q 'SCRUB redacted=' "$TMP/err.txt"; then
+  _ok "scrub emits redaction count on stderr"
+else
+  _no "scrub did not emit a redaction count"
+fi
+
+# ── (2b) Fail-closed: a binary payload must be refused (exit 4) ───────────────
+BIN="$TMP/binary.bin"
+printf 'before\000after-secret-AKIAIOSFODNN7EXAMPLE' > "$BIN"
+if "$SCRUB" "$BIN" >/dev/null 2>"$TMP/binerr.txt"; then
+  _no "scrubber egressed a binary payload (should refuse, exit 4)"
+else
+  RC=$?
+  if [ "$RC" = "4" ]; then _ok "binary payload refused (exit 4 -> launcher aborts egress)"; else _no "binary payload wrong exit ($RC, expected 4)"; fi
+fi
+
+rm -rf "$TMP"
+
+echo ""
+echo "egress-scrub-wired: $PASS passed, $FAIL failed"
+[ "$FAIL" -eq 0 ]

--- a/marketplace/plugin/tests/unit/test-peer-review-scrub.sh
+++ b/marketplace/plugin/tests/unit/test-peer-review-scrub.sh
@@ -1,0 +1,83 @@
+#!/bin/bash
+# Unit test: bin/peer-review-payload-scrub.sh — A10 outbound egress scrubber.
+# Contract:
+#   peer-review-payload-scrub.sh <file>
+#   - stdout: scrubbed payload (scrub_text applied from lib/privacy-sanitize.sh)
+#   - stderr: "SCRUB redacted=<N> ..." notice (N = redaction tokens introduced)
+#   - exit 0 : ok (redacted >= 0)
+#   - exit 2 : usage error (missing arg / unreadable file)
+#   - exit 3 : oversize (> 500 KB) — caller decides (AskUserQuestion)
+#   - exit 4 : binary (non-text mime) — refuse to egress
+set -u
+PLUGIN_ROOT="$(dirname "$(dirname "$(dirname "$(realpath "$0")")")")"
+SCRUB="$PLUGIN_ROOT/bin/peer-review-payload-scrub.sh"
+
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+PASS=0; FAIL=0
+_ok() { PASS=$((PASS+1)); echo "  OK  $1"; }
+_no() { FAIL=$((FAIL+1)); echo "  X   $1"; }
+
+# 1) clean text passes through unchanged, exit 0
+printf 'Please review this diff: function add(a,b){return a+b}\n' > "$TMP/clean.txt"
+OUT=$(bash "$SCRUB" "$TMP/clean.txt" 2>/dev/null); RC=$?
+[ "$RC" = "0" ] && _ok "clean text exit 0" || _no "clean text expected exit 0, got $RC"
+case "$OUT" in *"function add(a,b)"*) _ok "clean text preserved" ;; *) _no "clean text mangled: $OUT" ;; esac
+
+# 2) AWS access key id redacted
+printf 'key is AKIAIOSFODNN7EXAMPLE in the config\n' > "$TMP/aws.txt"
+OUT=$(bash "$SCRUB" "$TMP/aws.txt" 2>/dev/null)
+case "$OUT" in
+  *AKIAIOSFODNN7EXAMPLE*) _no "AWS key LEAKED in output" ;;
+  *"<AWS-KEY-ID>"*) _ok "AWS key redacted" ;;
+  *) _no "AWS key not handled: $OUT" ;;
+esac
+
+# 3) JWT redacted
+printf 'token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0.dozjgNryP4J3jVmNHl0w5N\n' > "$TMP/jwt.txt"
+OUT=$(bash "$SCRUB" "$TMP/jwt.txt" 2>/dev/null)
+case "$OUT" in *"<JWT>"*) _ok "JWT redacted" ;; *eyJhbGci*) _no "JWT LEAKED" ;; *) _no "JWT not handled" ;; esac
+
+# 4) OpenAI-style key redacted
+printf 'export OPENAI_API_KEY=sk-proj-abcdefghijklmnopqrstuvwxyz0123\n' > "$TMP/oai.txt"
+OUT=$(bash "$SCRUB" "$TMP/oai.txt" 2>/dev/null)
+case "$OUT" in
+  *"sk-proj-abcdefghijklmnop"*) _no "OpenAI key LEAKED" ;;
+  *"<OPENAI-KEY>"*) _ok "OpenAI key redacted" ;;
+  *) _no "OpenAI key not handled: $OUT" ;;
+esac
+
+# 5) stderr reports a redaction count > 0 when secrets present
+ERR=$(bash "$SCRUB" "$TMP/aws.txt" 2>&1 >/dev/null)
+case "$ERR" in *redacted=*) _ok "stderr emits redacted= count" ;; *) _no "no redacted= notice on stderr: $ERR" ;; esac
+# redacted should be 0 for clean text
+ERR0=$(bash "$SCRUB" "$TMP/clean.txt" 2>&1 >/dev/null)
+case "$ERR0" in *redacted=0*) _ok "clean text redacted=0" ;; *) _no "clean text not redacted=0: $ERR0" ;; esac
+
+# 6) missing arg -> exit 2
+bash "$SCRUB" >/dev/null 2>&1; RC=$?
+[ "$RC" = "2" ] && _ok "missing arg exit 2" || _no "missing arg expected 2, got $RC"
+
+# 7) unreadable / nonexistent file -> exit 2
+bash "$SCRUB" "$TMP/does-not-exist.txt" >/dev/null 2>&1; RC=$?
+[ "$RC" = "2" ] && _ok "missing file exit 2" || _no "missing file expected 2, got $RC"
+
+# 8) oversize (>500KB) -> exit 3
+head -c 600000 /dev/zero | tr '\0' 'a' > "$TMP/big.txt"
+bash "$SCRUB" "$TMP/big.txt" >/dev/null 2>&1; RC=$?
+[ "$RC" = "3" ] && _ok "oversize exit 3" || _no "oversize expected 3, got $RC"
+
+# 9) binary input -> exit 4
+printf '\x89PNG\r\n\x1a\n\x00\x00\x00\rIHDR\x00\x00' > "$TMP/img.bin"
+bash "$SCRUB" "$TMP/img.bin" >/dev/null 2>&1; RC=$?
+[ "$RC" = "4" ] && _ok "binary input exit 4" || _no "binary expected 4, got $RC"
+
+# 10) multiple secrets -> redacted count >= 2
+printf 'AKIAIOSFODNN7EXAMPLE and ghp_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\n' > "$TMP/multi.txt"
+ERR=$(bash "$SCRUB" "$TMP/multi.txt" 2>&1 >/dev/null)
+N=$(printf '%s' "$ERR" | sed -nE 's/.*redacted=([0-9]+).*/\1/p')
+[ "${N:-0}" -ge 2 ] && _ok "multiple secrets redacted>=2 (got $N)" || _no "expected redacted>=2, got ${N:-none}"
+
+echo ""
+echo "test-peer-review-scrub: $PASS passed, $FAIL failed"
+exit "$FAIL"


### PR DESCRIPTION
## What & why

Closes a **confirmed data-leak path**: both peer-review lanes (codex-sutra, deepseek) sent raw diffs/prompts to third-party APIs (OpenAI, DeepSeek) with **zero scrubbing**. The scrubber `bin/peer-review-payload-scrub.sh` existed but was (1) **unwired**, (2) **broken**, (3) **non-executable**.

Implements Sprint 1 #1 of the AI-engineering verification (A10, the only item with irreversible-harm risk).

## Changes

| # | Change | File |
|---|---|---|
| 1 | Fix NUL-detect bug: `grep -qU $'\x00'` is an empty pattern in bash → flagged **all text as binary**. Replaced with `tr -d '\000' \| cmp -s`. | `bin/peer-review-payload-scrub.sh` |
| 2 | Add execute bit (was `-rw-r--r--`; launchers call it directly → exit 126) | `bin/peer-review-payload-scrub.sh` |
| 3 | Wire deepseek: `$PROMPT_FILE` → scrub → `--rawfile $PROMPT_FILE_SCRUBBED`, fail-closed (SKIPPED gate-log on error, no egress) | `skills/deepseek/SKILL.md` |
| 4 | Wire codex-sutra: prompt → scrub → `$SCRUBBED_PROMPT` for `codex exec` | `skills/codex-sutra/SKILL.md` |
| 5 | Flip `TODO[v2-scrubber]` → DONE | `skills/deepseek/SKILL.md` |
| 6 | New integration test (14 assertions) | `tests/integration/test-egress-scrub-wired.sh` |

## Honest scope

- **deepseek**: fully closed (pure API; the prompt IS the payload).
- **codex-sutra**: partially closed. Scrubs content Claude *embeds* (design-review files, consult plans). Does NOT scrub what `codex exec -s read-only -C $REPO` reads **itself** (git diff, source files) — needs codex-side redaction or a pre-scrubbed worktree. Tracked as `TODO[v2-codex-sandbox-scrub]`.

## Verification

- `test-peer-review-scrub.sh`: **12/12** (was 4/12 broken before the NUL fix)
- `test-egress-scrub-wired.sh`: **14/14** — proves AWS/OpenAI/JWT keys → placeholders, non-secret content preserved, binary refused (exit 4)
- No regressions: the 5 other suite failures were proven pre-existing via clean-baseline re-run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)